### PR TITLE
Fix allowed url pattern to allow urls with /jira 

### DIFF
--- a/src/main/java/com/epam/reportportal/extension/jira/utils/IntegrationValidator.java
+++ b/src/main/java/com/epam/reportportal/extension/jira/utils/IntegrationValidator.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  */
 public final class IntegrationValidator {
 
-  private static final String JIRA_URL_PATTERN = "https://[^?]*\\.(atlassian\\.(com|net)|jira\\.com)/?$";
+  private static final String JIRA_URL_PATTERN = "https://[^?]*\\.(atlassian\\.(com|net)|jira\\.com)(/jira)?/?$";
 
   private IntegrationValidator() {
     //static only

--- a/src/test/java/com/epam/reportportal/extension/jira/utils/IntegrationValidatorTest.java
+++ b/src/test/java/com/epam/reportportal/extension/jira/utils/IntegrationValidatorTest.java
@@ -36,6 +36,10 @@ class IntegrationValidatorTest {
       "https://atlassian.jira.com/",
       "https://another.jira.com/",
       "https://another.jira.com",
+      "https://acme.atlassian.net/jira",
+      "https://acme.atlassian.com/jira",
+      "https://acme.atlassian.net/jira/",
+      "https://acme.atlassian.com/jira/"
   }, delimiter = ',')
   void validateThirdPartyUrl(String url) {
     Assertions.assertDoesNotThrow(() ->
@@ -49,7 +53,11 @@ class IntegrationValidatorTest {
       "https://zloi.hacker.com?jira=fake.atlassian.com",
       "https://jira.com.zloi.hacker.net",
       "https://jira.com.zloi.hacker.net/",
-      "https://another.jira.com/admin"
+      "https://another.jira.com/admin",
+      "http://acme.atlassian.net/jira",
+      "https://acme.atlassian.net/jira/admin",
+      "https://acme.atlassian.net/jira?tab=1",
+      "https://acme.atlassian.net/jira#anchor"
   }, delimiter = ',')
   void validateThirdPartyUrlFailed(String url) {
     Assertions.assertThrows(ReportPortalException.class, () ->


### PR DESCRIPTION
This is a bug fix to the url pattern matcher as described in this issue - https://github.com/reportportal/plugin-bts-jira-cloud/issues/121

Valid urls such as
https://acme.atlassian.net/jira
https://acme.atlassian.net/jira/
are currently being blocker by the validator. The official Atlassian documentation states that these are valid urls - https://support.atlassian.com/organization-administration/docs/update-your-product-and-site-url/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JIRA URL validation to accept more URL formats, including those with optional `/jira` path segments and trailing slashes, improving integration setup flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->